### PR TITLE
Optimize maven build phase and add volumes for maven and npm

### DIFF
--- a/customer-core/Dockerfile
+++ b/customer-core/Dockerfile
@@ -1,8 +1,8 @@
-FROM maven:3.5.2-jdk-8 AS build
+FROM maven:3.6.1-jdk-8-alpine AS build
 ARG BASE=/usr/src/app
 COPY pom.xml ${BASE}/
 COPY src ${BASE}/src
-RUN mvn -f ${BASE}/pom.xml install
+RUN mvn -f ${BASE}/pom.xml install -DskipTests
 
 FROM openjdk:8-jdk-alpine
 COPY --from=build /usr/src/app/target/dependency/BOOT-INF/lib/* /app/lib/

--- a/customer-management-backend/Dockerfile
+++ b/customer-management-backend/Dockerfile
@@ -1,8 +1,8 @@
-FROM maven:3.5.2-jdk-8 AS build
+FROM maven:3.6.1-jdk-8-alpine AS build
 ARG BASE=/usr/src/app
 COPY pom.xml ${BASE}/
 COPY src ${BASE}/src
-RUN mvn -f ${BASE}/pom.xml install
+RUN mvn -f ${BASE}/pom.xml install -DskipTests
 
 FROM openjdk:8-jdk-alpine
 COPY --from=build /usr/src/app/target/dependency/BOOT-INF/lib/* /app/lib/

--- a/customer-self-service-backend/Dockerfile
+++ b/customer-self-service-backend/Dockerfile
@@ -1,8 +1,8 @@
-FROM maven:3.5.2-jdk-8 AS build
+FROM maven:3.6.1-jdk-8-alpine AS build
 ARG BASE=/usr/src/app
 COPY pom.xml ${BASE}/
 COPY src ${BASE}/src
-RUN mvn -f ${BASE}/pom.xml install
+RUN mvn -f ${BASE}/pom.xml install -DskipTests
 
 FROM openjdk:8-jdk-alpine
 COPY --from=build /usr/src/app/target/dependency/BOOT-INF/lib/* /app/lib/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ services:
       - "SPRING_BOOT_ADMIN_CLIENT_URL=http://spring-boot-admin:9000"
     ports:
       - "8110:8110"
+    volumes:
+      - "maven_repo:/root/.m2"
   customer-management-backend:
     build: customer-management-backend
     image: lakesidemutual/customer-management-backend
@@ -32,6 +34,8 @@ services:
       - "SPRING_BOOT_ADMIN_CLIENT_URL=http://spring-boot-admin:9000"
     ports:
       - "8100:8100"
+    volumes:
+      - "maven_repo:/root/.m2"
   customer-management-frontend:
     build: customer-management-frontend
     image: lakesidemutual/customer-management-frontend
@@ -41,6 +45,8 @@ services:
       - "REACT_APP_CUSTOMER_MANAGEMENT_BACKEND=http://customer-management-backend:8100"
     ports:
       - "3020:80"
+    volumes:
+      - "node_modules:/usr/src/app/node_modules"
   customer-self-service-backend:
     build: customer-self-service-backend
     image: lakesidemutual/customer-self-service-backend
@@ -51,6 +57,8 @@ services:
       - "SPRING_BOOT_ADMIN_CLIENT_URL=http://spring-boot-admin:9000"
     ports:
       - "8080:8080"
+    volumes:
+      - "maven_repo:/root/.m2"
   customer-self-service-frontend:
     build: customer-self-service-frontend
     image: lakesidemutual/customer-self-service-frontend
@@ -64,6 +72,8 @@ services:
       - "REACT_APP_CUSTOMER_MANAGEMENT_BACKEND=http://customer-management-backend:8100"
     ports:
       - "3000:80"
+    volumes:
+      - "node_modules:/usr/src/app/node_modules"
   policy-management-backend:
     build: policy-management-backend
     image: lakesidemutual/policy-management-backend
@@ -75,6 +85,8 @@ services:
     ports:
       - "8090:8090"
       - "61613:61613"
+    volumes:
+      - "maven_repo:/root/.m2"
   policy-management-frontend:
     build: policy-management-frontend
     image: lakesidemutual/policy-management-frontend
@@ -84,11 +96,15 @@ services:
       - "VUE_APP_POLICY_MANAGEMENT_BACKEND=http://policy-management-backend:8090"
     ports:
       - "3010:80"
+    volumes:
+      - "node_modules:/usr/src/app/node_modules"
   spring-boot-admin:
     build: spring-boot-admin
     image: lakesidemutual/spring-boot-admin
     ports:
       - "9000:9000"
+    volumes:
+      - "maven_repo:/root/.m2"
   risk-management-server:
     build: risk-management-server
     image: lakesidemutual/risk-management-server
@@ -99,3 +115,8 @@ services:
       - "activeMQ.port=61613"
     ports:
       - "50051:50051"
+    volumes:
+      - "node_modules:/usr/src/app/node_modules"
+volumes:
+  maven_repo:
+  node_modules:

--- a/policy-management-backend/Dockerfile
+++ b/policy-management-backend/Dockerfile
@@ -1,8 +1,8 @@
-FROM maven:3.5.2-jdk-8 AS build
+FROM maven:3.6.1-jdk-8-alpine AS build
 ARG BASE=/usr/src/app
 COPY pom.xml ${BASE}/
 COPY src ${BASE}/src
-RUN mvn -f ${BASE}/pom.xml install
+RUN mvn -f ${BASE}/pom.xml install -DskipTests
 
 FROM openjdk:8-jdk-alpine
 COPY --from=build /usr/src/app/target/dependency/BOOT-INF/lib/* /app/lib/

--- a/spring-boot-admin/Dockerfile
+++ b/spring-boot-admin/Dockerfile
@@ -1,8 +1,8 @@
-FROM maven:3.5.2-jdk-8 AS build
+FROM maven:3.6.1-jdk-8-alpine AS build
 ARG BASE=/usr/src/app
 COPY pom.xml ${BASE}/
 COPY src ${BASE}/src
-RUN mvn -f ${BASE}/pom.xml install
+RUN mvn -f ${BASE}/pom.xml install -DskipTests
 
 FROM openjdk:8-jdk-alpine
 COPY --from=build /usr/src/app/target/dependency/BOOT-INF/lib/* /app/lib/


### PR DESCRIPTION
Reusing the .m2 dir <https://hub.docker.com/_/maven#reusing-the-maven-local-repository>

Use maven alpine to reduce image size

Skip maven tests for the build phase