### PR TITLE
Running Docker/Docker-Compose (BuildKit required)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,20 @@ consult the README of the corresponding component:
 
 All projects come with Dockerfiles that can be used to run the services as Docker containers. The [docker-compose.yml](./docker-compose.yml) builds and starts all applications in a single command, just like the `run_all_applications` scripts mentioned above. See the [docker-compose.yml](./docker-compose.yml) for more information.
 
+Note that the Dockerfiles make use of [BuildKit](https://docs.docker.com/develop/develop-images/build_enhancements/) features. To be able to build the Docker images, you have to set the `DOCKER_BUILDKIT` environment variable accoringly.
+
+The easiest way to build the individual images is by running the following command in the corresponding project directory:
+
+```bash
+DOCKER_BUILDKIT=1 docker build
+```
+
+To build and run all applications with Docker Compose, use the following command:
+
+```bash
+COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose up
+```
+
 ## Data Stores
 
 Each backend service has its own data store. The Spring-JPA based applications all use the H2 relational database. By default, all data will be lost during restarts, please see the individual README files to enable durable persistency. The backend services also contain the H2 Console to browse the database. It can be found at `/console`. For example, for the Customer Core, the address is [http://localhost:8110/console](http://localhost:8110/console).

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ consult the README of the corresponding component:
 
 All projects come with Dockerfiles that can be used to run the services as Docker containers. The [docker-compose.yml](./docker-compose.yml) builds and starts all applications in a single command, just like the `run_all_applications` scripts mentioned above. See the [docker-compose.yml](./docker-compose.yml) for more information.
 
-Note that the Dockerfiles make use of [BuildKit](https://docs.docker.com/develop/develop-images/build_enhancements/) features. To be able to build the Docker images, you have to set the `DOCKER_BUILDKIT` environment variable accoringly.
+Note that the Dockerfiles make use of [BuildKit](https://docs.docker.com/develop/develop-images/build_enhancements/) features. To be able to build the Docker images, you have to set the `DOCKER_BUILDKIT` environment variable accordingly.
 
 The easiest way to build the individual images is by running the following command in the corresponding project directory:
 

--- a/docker-compose-eureka.yml
+++ b/docker-compose-eureka.yml
@@ -5,11 +5,14 @@
 # or other development features. For development, we recommend to start
 # the applications invidually or use the run_all_applications scripts.
 #
+# Since the Dockerfiles use BuildKit features, you have to set the
+# DOCKER_BUILDKIT environment variable accordingly.
+#
 # To build the Docker images:
-#   docker-compose -f docker-compose-eureka.yml build
+#   COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose -f docker-compose-eureka.yml build
 #
 # To run the applications:
-#   docker-compose -f docker-compose-eureka.yml up
+#   COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose -f docker-compose-eureka.yml up
 #
 # To shut down the applications, simply terminate the previous command.
 #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,14 @@
 # or other development features. For development, we recommend to start
 # the applications invidually or use the run_all_applications scripts.
 #
+# Since the Dockerfiles use BuildKit features, you have to set the
+# DOCKER_BUILDKIT environment variable accordingly.
+#
 # To build the Docker images:
-#   docker-compose build
+#   COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose build
 #
 # To run the applications:
-#   docker-compose up
+#   COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose up
 #
 # To shut down the applications, simply terminate the previous command.
 #


### PR DESCRIPTION
I suggest to improve the Docker documentation a bit here... With [one of the latest commits](https://github.com/Microservice-API-Patterns/LakesideMutual/commit/5e7b1d726249f06204800cb16575fe3633e26814) Docker BuildKit became required and calling Docker or Docker-Compose is only possible if `DOCKER_BUILDKIT=1` env var is set.