### PR TITLE
added .env file in policy management frontend Dockerfile

### DIFF
--- a/policy-management-frontend/Dockerfile
+++ b/policy-management-frontend/Dockerfile
@@ -14,6 +14,7 @@ WORKDIR /usr/share/nginx/html
 
 RUN apk add --no-cache nodejs npm
 RUN npm install -g @beam-australia/react-env@3.1.1
+ADD .env ./
 ADD entrypoint.sh /var/entrypoint.sh
 ENTRYPOINT ["/var/entrypoint.sh"]
 


### PR DESCRIPTION
Modified Dockerfile of `Policy management frontend service` to copy the .env file. As discussed [here](https://github.com/Microservice-API-Patterns/LakesideMutual/issues/25#issuecomment-1381817164) 

**Resolves:** https://github.com/Microservice-API-Patterns/LakesideMutual/issues/25

Signed-off-by: odidev odidev@puresoftware.com